### PR TITLE
add API key as HTTP header instead of Authority

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -48,6 +48,10 @@ impl SkynetClient {
     self.portal_url.as_str()
   }
 
+  pub fn get_options(&self) -> &SkynetClientOptions {
+    &self.options
+  }
+
   pub async fn upload_data(
     &self,
     data: HashMap<String, (Mime, Vec<u8>)>,

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -114,7 +114,7 @@ pub async fn upload_data(
     .uri(uri)
     .header("Content-Type", content_type);
 
-  if let Some(apikey) = &opt.api_key {
+  if let Some(apikey) = &opt.api_key.or(client.get_options().api_key.clone()) {
     req = req.header("Skynet-Api-Key", apikey.clone());
   }
 

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -129,9 +129,9 @@ pub async fn upload_data(
   let res: UploadResponse = serde_json::from_str(body_str)
     .map_err(|_| PortalResponse(body_str.to_string()))?;
 
-  let skylink = format!("{}{}", URI_SKYNET_PREFIX, res.skylink);
+  // let skylink = format!("{}{}", URI_SKYNET_PREFIX, res.skylink);
 
-  Ok(skylink)
+  Ok(res.skylink)
 }
 
 pub async fn upload_file(

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -103,11 +103,20 @@ pub async fn upload_data(
     mime::MULTIPART_FORM_DATA,
     str::from_utf8(&boundary).map_err(Utf8Error)?);
 
-  let uri = make_uri(client.get_portal_url(), opt.endpoint_path, opt.api_key, None, query);
+  let uri = make_uri(
+    client.get_portal_url(),
+    opt.endpoint_path,
+    opt.api_key.clone(),
+    None,
+    query);
 
   let mut req = req
     .uri(uri)
     .header("Content-Type", content_type);
+
+  if let Some(apikey) = &opt.api_key {
+    req = req.header("Skynet-Api-Key", apikey.clone());
+  }
 
   if let Some(custom_user_agent) = opt.custom_user_agent {
     req = req.header("User-Agent", custom_user_agent);

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,11 +16,13 @@ pub fn make_uri(
   let scheme = parts[0];
   let host = parts[1];
 
-  let authority: Authority = if let Some(api_key) = api_key {
-    format!("{}@{}", api_key, host).parse().unwrap()
-  } else {
-    host.parse().unwrap()
-  };
+  // let authority: Authority = if let Some(api_key) = api_key {
+  //   format!("{}@{}", api_key, host).parse().unwrap()
+  // } else {
+  //   host.parse().unwrap()
+  // };
+
+  let authority: Authority = host.parse().unwrap();
 
   let extra_path = if let Some(extra_path) = extra_path {
     format!("/{}", extra_path)


### PR DESCRIPTION
The Skynet SDK may have diverged after skynet-rs's last update. It currently needs an HTTP header for authentication using API key.